### PR TITLE
Fixing error regarding pdf response body parsing

### DIFF
--- a/lib/reggora/Adapters/requests.rb
+++ b/lib/reggora/Adapters/requests.rb
@@ -73,7 +73,11 @@ module Reggora
 
     def handle_response(response)
       print "\n------ Response -----\n"
-      puts response.read_body
+      begin
+        puts response.read_body
+      rescue
+        puts "Error printing response body"
+      end
       print "---------------------------"
       case response
       when Net::HTTPSuccess then


### PR DESCRIPTION
Issue #9 

I was wrong in the issue description. The issue was actually just trying to puts a pdf. The non-ASCII characters caused a breaking error.